### PR TITLE
fix issue when installing pro version with external clickhouse and kafka

### DIFF
--- a/charts/featbit/templates/_helpers.tpl
+++ b/charts/featbit/templates/_helpers.tpl
@@ -398,7 +398,7 @@ Return the ClickHouse secret key
 {{- define "featbit.clickhouse.secretPasswordKey" -}}
 {{- if and .Values.clickhouse.enabled .Values.clickhouse.auth.existingSecret -}}
     {{- required "You need to provide existingSecretPasswordKey when an existingSecret is specified in Clickhouse" .Values.clickhouse.auth.existingSecretKey | printf "%s" -}}
-{{- else if and (not .Values.redis.enabled) .Values.externalRedis.existingSecret -}}
+{{- else if and (not .Values.clickhouse.enabled) .Values.externalClickhouse.existingSecret -}}
     {{- required "You need to provide existingSecretPasswordKey when an existingSecret is specified in external Clickhouse" .Values.externalClickhouse.existingSecretKey | printf "%s" -}}
 {{- else -}}
     {{- printf "admin-password" -}}

--- a/charts/featbit/templates/_pro-env.tpl
+++ b/charts/featbit/templates/_pro-env.tpl
@@ -17,20 +17,20 @@
       key: {{ include "featbit.clickhouse.secretPasswordKey" . }}
 - name: CLICKHOUSE_DATABASE
   value: {{ include "featbit.clickhouse.database" . }}
-{{- if (not .Values.clickhouse.enabled) -}}
+{{- if (not .Values.clickhouse.enabled) }}
 - name: CLICKHOUSE_SECURE
   value: {{ .Values.externalClickhouse.secure | quote }}
 - name: CLICKHOUSE_VERIFY
   value: {{ .Values.externalClickhouse.verify | quote }}
-{{- if .Values.externalClickhouse.cluster -}}
+{{- if .Values.externalClickhouse.cluster }}
 - name: CLICKHOUSE_CLUSTER
   value: {{ .Values.externalClickhouse.cluster | quote }}
-{{- else -}}
+{{- else }}
 - name: CLICKHOUSE_REPLICATION
   value: "false"
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end -}}
 
 {{- define "kafka-bootstrapservers" -}}
@@ -39,7 +39,7 @@
   value: "true"
 - name: Kafka__BootstrapServers
   value: {{ include "featbit.kafka.brokers" . }}
-{{- end -}}
+{{- end }}
 {{- end -}}
 
 {{- define "clickhouse-usr-pass" -}}
@@ -51,5 +51,5 @@
     secretKeyRef:
       name: {{ include "featbit.clickhouse.secretName" . }}
       key: {{ include "featbit.clickhouse.secretPasswordKey" . }}
-{{- end -}}
+{{- end }}
 {{- end -}}


### PR DESCRIPTION
Encountered the following error when deploying with external clickhouse
```
clickhouse:
  enabled: false
```

```
Error: INSTALLATION FAILED: YAML parse error on featbit/templates/da-server-deployment.yaml: error converting YAML to JSON: yaml: line 151: mapping values are not allowed in this context
```

to verify add/change the following in examples/featbitpro.yaml

```
clickhouse:
  enabled: false

externalClickhouse:
  ## Hostname or ip address of external clickhouse
  ##
  host: "clickhouse.featbit.svc.cluster.local"
  tcpPort: 9000
  httpPort: 8123
  username: default
  password: "featbit"
  database: default
  singleNode: false  
```
  
using the main branch run 
`helm install featbit ./ -f .\examples\featbit-pro.yaml --dry-run --debug -n featbit`

Observe the error

Switch to this PR using the same values from above in featbitpro.yaml and run the helm install again, observe that the chart manifests are created.

This was due to some issues with if statements in `_pro-env.tpl`. while investigating this issue it was also discovered that `featbit.clickhouse.secretPasswordKey` in `_helpers.tpl` was evaluating redis settings instead of clickhouse settings, this has been corrected.
  