### PR TITLE
fix Clickhouse external secret

### DIFF
--- a/charts/featbit/templates/clickhouse-external-secret.yaml
+++ b/charts/featbit/templates/clickhouse-external-secret.yaml
@@ -10,5 +10,5 @@ metadata:
     {{- include "featbit-metadata-annotations-common" . | nindent 4 }}
 type: Opaque
 data:
-  {{ template "featbit.clickhouse.secretPasswordKey" . }}: {{ .Values.externalRedis.password | b64enc | quote }}
+  {{ template "featbit.clickhouse.secretPasswordKey" . }}: {{ .Values.externalClickhouse.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
clickhouse-external-secret.yaml was reading `externalRedis.password` instead of `externalClickhouse.password`. This PR corrects that.