### PR TITLE
🐛 Indentation fix for api deployment environment variables

### DIFF
--- a/charts/featbit/templates/api-deployment.yaml
+++ b/charts/featbit/templates/api-deployment.yaml
@@ -73,7 +73,7 @@ spec:
             {{- include "mongodb-env" . | indent 12 }}
             {{- include "kafka-bootstrapservers" . | indent 12 -}}
             {{- with .Values.api.env }}
-            {{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
This PR addresses an issue with the `api-deployment.yaml` template when additional environment variables defined in the values file. Currently when additional environment variables are added the chart fails to render with the message `Error: YAML parse error on featbit/templates/api-deployment.yaml: error converting YAML to JSON: yaml: line 131: mapping values are not allowed in this context`

To test this PR, follow these steps

1. Run the following command
  `helm template featbit . -f values.yaml  --debug -s templates\api-deployment.yaml`
2. Observe that the api-deployment template is rendered
3. Add the following to the `values.yaml` file in the `api` section at lines `187-189` 
```
env:
    - name: DUMMY_VAR
      value: "dummy value"
```
4. Run the following command
  `helm template featbit . -f values.yaml  --debug -s templates\api-deployment.yaml`
5. Observe the error `Error: YAML parse error on featbit/templates/api-deployment.yaml: error converting YAML to JSON: yaml: line 131: mapping values are not allowed in this context`
6. Apply this PR
7. Repeat steps 3 & 4
8. Observe that the api-deployment template is rendered with the DUMMY_VAR included.