### PR TITLE
🐛 Fix env values in values.yml

### DIFF
--- a/charts/featbit/templates/da-server-deployment.yaml
+++ b/charts/featbit/templates/da-server-deployment.yaml
@@ -73,7 +73,7 @@ spec:
             {{- include "mongodb-env" . | indent 12 }}
             {{- include "das-pro-env" . | indent 12 }}
             {{- with .Values.das.env }}
-            {{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
       {{- with .Values.das.nodeSelector }}
       nodeSelector:

--- a/charts/featbit/templates/eval-server-deployment.yaml
+++ b/charts/featbit/templates/eval-server-deployment.yaml
@@ -71,7 +71,7 @@ spec:
             {{- include "mongodb-env" . | indent 12 }}
             {{- include "kafka-bootstrapservers" . | indent 12 -}}
             {{- with .Values.els.env }}
-            {{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
       {{- with .Values.els.nodeSelector }}
       nodeSelector:

--- a/charts/featbit/templates/ui-deployment.yaml
+++ b/charts/featbit/templates/ui-deployment.yaml
@@ -100,7 +100,7 @@ spec:
               value: "/shared/evaluation_url.txt"
             {{- end }}
             {{- with .Values.ui.env }}
-            {{ toYaml . | indent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: scripts

--- a/charts/featbit/values.yaml
+++ b/charts/featbit/values.yaml
@@ -106,7 +106,7 @@ ui:
   affinity: { }
 
   # -- Additional env variables to inject into the da server deployment.
-  env: { }
+  env: []
 
 api:
   replicaCount: 1
@@ -184,7 +184,7 @@ api:
   affinity: { }
 
   # -- Additional env variables to inject into the da server deployment.
-  env: { }
+  env: []
 
 els:
   replicaCount: 1
@@ -262,7 +262,7 @@ els:
   affinity: { }
 
   # -- Additional env variables to inject into the da server deployment.
-  env: { }
+  env: []
 
 
 das:
@@ -331,7 +331,7 @@ das:
   affinity: { }
 
   # -- Additional env variables to inject into the da server deployment.
-  env: { }
+  env: []
 
 
 ###


### PR DESCRIPTION
This PR fixes an issue with adding environment variables to a custom values.yml file.

To observe this bug create a override-values.yml file with the following.
```
api:
    image:
      registry: harbor.clarkinc.biz
      repository: apps/featbit/featbit-api-server
      pullPolicy: IfNotPresent
      # Overrides the image tag whose default is the chart appVersion.
      tag: feat-logging-8e70aeab
    env:
      - name: SSO__ENABLED
        value: "true"
```
next, execute the following command
```
helm install featbit featbit/featbit  --values override-values.yaml
```
Observe an error similar to the following.
```
coalesce.go:220: warning: cannot overwrite table with non table for featbit.api.env (map[]) 
```

Apply this PR and attempt to install the chart again and the error will not appear.

The problem is that the base value.yml file defines env as an empty object rather than an empty array.
      

