### PR TITLE
fix: das-test-connection.yaml invalid rendering of image name

### DIFF
--- a/charts/featbit/templates/tests/das-test-connection.yaml
+++ b/charts/featbit/templates/tests/das-test-connection.yaml
@@ -9,8 +9,8 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: {{ .Values.busybox.image }}
-      imagePullPolicy: {{ .Values.busybox.pullPolicy }}
+      image: {{ include "featbit.init-container.busybox.image" . }}
+      imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
       command: ['wget']
       args: ['{{ include "das.svc.name" . }}:{{ include "das.svc.port" .}}/api']
   restartPolicy: Never


### PR DESCRIPTION
## What

Fixes the incorrect rendering of the imageName value `das-test-connection.yaml` template

Fixes: https://github.com/featbit/featbit-charts/issues/37


##How

- By re-using the `featbit.init-container.busbox` util definition so that the busybox image name is centralized
- By updating the `imagePullPolicy` to read directly from the `Values.yaml` correct locatuon


## Why

This is so that we can successfully run the `das-test-connection` helm test using `helm test featbit` and deploy all manifests successfully, Fixing the `InvalidImageName` error.