### PR TITLE
Add extra containers

### DIFF
--- a/charts/featbit/templates/api-deployment.yaml
+++ b/charts/featbit/templates/api-deployment.yaml
@@ -42,6 +42,11 @@ spec:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "initContainers-wait-for-infrastructure-dependencies" (dict "context" . "component" "api") | indent 8 }}
+        {{- if .Values.api.extraInitContainers }}
+        {{- with .Values.api.extraInitContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-api
           securityContext:
@@ -80,6 +85,11 @@ spec:
             {{- with .Values.api.env }}
             {{ toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.api.extraContainers }}
+        {{- with .Values.api.extraContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.api.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/featbit/templates/da-server-deployment.yaml
+++ b/charts/featbit/templates/da-server-deployment.yaml
@@ -42,6 +42,11 @@ spec:
         {{- toYaml .Values.das.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "initContainers-wait-for-infrastructure-dependencies" (dict "context" . "component" "das") | indent 8 }}
+        {{- if .Values.das.extraInitContainers }}
+        {{- with .Values.das.extraInitContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-das
           securityContext:
@@ -78,6 +83,11 @@ spec:
             {{- with .Values.das.env }}
             {{ toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.das.extraContainers }}
+        {{- with .Values.das.extraContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.das.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/featbit/templates/eval-server-deployment.yaml
+++ b/charts/featbit/templates/eval-server-deployment.yaml
@@ -42,6 +42,11 @@ spec:
         {{- toYaml .Values.els.podSecurityContext | nindent 8 }}
       initContainers:
         {{- include "initContainers-wait-for-infrastructure-dependencies" (dict "context" . "component" "els") | indent 8 }}
+        {{- if .Values.els.extraInitContainers }}
+        {{- with .Values.els.extraInitContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}-els
           securityContext:
@@ -76,6 +81,11 @@ spec:
             {{- with .Values.els.env }}
             {{ toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.els.extraContainers }}
+        {{- with .Values.els.extraContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.els.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/featbit/templates/ui-deployment.yaml
+++ b/charts/featbit/templates/ui-deployment.yaml
@@ -61,6 +61,10 @@ spec:
             - name: scripts
               mountPath: /scripts/auto-discovery.sh
               subPath: auto-discovery.sh
+        {{- if .Values.ui.extraInitContainers }}
+        {{- with .Values.ui.extraInitContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ui
@@ -112,6 +116,11 @@ spec:
             - name: shared
               mountPath: /shared
             {{- end }}
+        {{- if .Values.ui.extraContainers }}
+        {{- with .Values.ui.extraContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+        {{- end }}
       volumes:
         - name: scripts
           configMap:


### PR DESCRIPTION
Our setup is on GCP and we are using google SQL for postgres. The recommended way to connect to the database is with [google's sql auth proxy](https://docs.cloud.google.com/sql/docs/postgres/sql-proxy).

And the easiest way of doing this is to have the proxy running as a sidecar container.

To do that we define `extraContainers` and `extraInitContainers`, and make this consistent in all the deployments so future considerations can also be handled with this - for example a telemetry collector or a logs file reader.

I have seen this pattern in a lot of software, for example [HashiCorp's consul](https://developer.hashicorp.com/consul/docs/reference/k8s/helm#v-server-extracontainers).

Since I'm not well versed with helmcharts, I've used this for reference:
https://github.com/gravitee-io/gravitee-api-management/blob/master/helm/templates/gateway/gateway-deployment.yaml
(A software that we are using and utilizing the extraContainers there)

