### PR TITLE
feat: Update readinessProbe path for API and Eval deployments

### DIFF
--- a/charts/featbit/Chart.yaml
+++ b/charts/featbit/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/featbit/templates/api-deployment.yaml
+++ b/charts/featbit/templates/api-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             httpGet:
-              path: /health/liveness
+              path: /health/readiness
               port: http
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}

--- a/charts/featbit/templates/eval-server-deployment.yaml
+++ b/charts/featbit/templates/eval-server-deployment.yaml
@@ -67,7 +67,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             httpGet:
-              path: /health/liveness
+              path: /health/readiness
               port: http
           resources:
             {{- toYaml .Values.els.resources | nindent 12 }}


### PR DESCRIPTION
Updated the readinessProbe path for the API and eval deployments from `health/liveness` to `health/readiness`.
Updated the chart version to 0.8.2.