### PR TITLE
v0.8.4: fix initContainers resource bug

### DIFF
--- a/charts/featbit/Chart.yaml
+++ b/charts/featbit/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.3
+version: 0.8.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/featbit/templates/_initContainers-wait-for-infrastructure-dependencies.tpl
+++ b/charts/featbit/templates/_initContainers-wait-for-infrastructure-dependencies.tpl
@@ -9,9 +9,9 @@
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with (get $ctx.Values $component).initContainers.resources }}
+  {{- if and (get $ctx.Values $component).initContainers (get $ctx.Values $component).initContainers.resources }}
   resources:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (get $ctx.Values $component).initContainers.resources | nindent 4 }}
   {{- end }}
   {{- if (include "featbit.isPro" $ctx) }}
   env:

--- a/charts/featbit/templates/_initContainers-wait-for-other-components.tpl
+++ b/charts/featbit/templates/_initContainers-wait-for-other-components.tpl
@@ -9,9 +9,9 @@
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with (get $ctx.Values $component).initContainers.resources }}
+  {{- if and (get $ctx.Values $component).initContainers (get $ctx.Values $component).initContainers.resources }}
   resources:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml (get $ctx.Values $component).initContainers.resources | nindent 4 }}
   {{- end }}
   command:
     - /bin/sh


### PR DESCRIPTION
This pull request makes improvements to the Helm chart templates for resource handling in init containers and bumps the chart version to reflect these changes. The main focus is on ensuring that resource specifications for init containers are only included when both the `initContainers` and their `resources` fields are present, which increases template robustness.

Helm chart template improvements:

* Updated both `_initContainers-wait-for-infrastructure-dependencies.tpl` and `_initContainers-wait-for-other-components.tpl` to only render the `resources` block for init containers if both `initContainers` and `initContainers.resources` are defined, preventing errors from missing fields. [[1]](diffhunk://#diff-4431bf5918949ae906a8696928711ce5c842efb2c78924d908b39366da98eea4L12-R14) [[2]](diffhunk://#diff-ce21de5457e02e51a5d02ea43fff805ef8a7370ceb67d34a497fb74edddd7e5cL12-R14)

Version update:

* Bumped the chart version from `0.8.3` to `0.8.4` in `Chart.yaml` to reflect the new changes.