### PR TITLE
Add VERSION environment variable to deployments

### DIFF
--- a/charts/featbit/templates/api-deployment.yaml
+++ b/charts/featbit/templates/api-deployment.yaml
@@ -86,6 +86,8 @@ spec:
             {{- include "otel-common-env" . | indent 12 }}
             {{- include "api-otel-env" . | indent 12 }}
             {{- include "kafka-bootstrapservers" . | indent 12 }}
+            - name: VERSION
+              value: {{ .Chart.AppVersion | quote }}
             {{- with .Values.api.env }}
             {{ toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/featbit/templates/eval-server-deployment.yaml
+++ b/charts/featbit/templates/eval-server-deployment.yaml
@@ -91,6 +91,8 @@ spec:
             - name: Streaming__TokenExpirySeconds
               value: {{ include "els.svc.streamingtokenexpiryseconds" . | quote }}
             {{- end }}
+            - name: VERSION
+              value: {{ .Chart.AppVersion | quote }}
             {{- with .Values.els.env }}
             {{ toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/featbit/templates/ui-deployment.yaml
+++ b/charts/featbit/templates/ui-deployment.yaml
@@ -123,6 +123,8 @@ spec:
             - name: SHARED_EVALUATION_URL_FILE
               value: "/shared/evaluation_url.txt"
             {{- end }}
+            - name: VERSION
+              value: {{ .Chart.AppVersion | quote }}
             {{- with .Values.ui.env }}
             {{ toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
The UI, ELS, and back-end modules now use a `VERSION` env variable. This sets that variable in the deployments to `.Chart.AppVersion`